### PR TITLE
Linux windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ class _AppState extends State<App> {
 | Platform | Supported |
 | -------- | --------- |
 | MacOS    | ✅        |
-| Linux    | ❌        |
+| Linux    | ✅        |
 | Windows  | ✅        |
 
 ## License

--- a/example/linux/.gitignore
+++ b/example/linux/.gitignore
@@ -1,0 +1,1 @@
+flutter/ephemeral

--- a/example/linux/CMakeLists.txt
+++ b/example/linux/CMakeLists.txt
@@ -1,0 +1,116 @@
+cmake_minimum_required(VERSION 3.10)
+project(runner LANGUAGES CXX)
+
+set(BINARY_NAME "native_context_menu_example")
+set(APPLICATION_ID "com.example.native_context_menu")
+
+cmake_policy(SET CMP0063 NEW)
+
+set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
+
+# Root filesystem for cross-building.
+if(FLUTTER_TARGET_PLATFORM_SYSROOT)
+  set(CMAKE_SYSROOT ${FLUTTER_TARGET_PLATFORM_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+endif()
+
+# Configure build options.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE
+    STRING "Flutter build mode" FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Profile" "Release")
+endif()
+
+# Compilation settings that should be applied to most targets.
+function(APPLY_STANDARD_SETTINGS TARGET)
+  target_compile_features(${TARGET} PUBLIC cxx_std_14)
+  target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+  target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
+  target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
+endfunction()
+
+set(FLUTTER_MANAGED_DIR "${CMAKE_CURRENT_SOURCE_DIR}/flutter")
+
+# Flutter library and tool build rules.
+add_subdirectory(${FLUTTER_MANAGED_DIR})
+
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+
+add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
+
+# Application build
+add_executable(${BINARY_NAME}
+  "main.cc"
+  "my_application.cc"
+  "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
+)
+apply_standard_settings(${BINARY_NAME})
+target_link_libraries(${BINARY_NAME} PRIVATE flutter)
+target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
+add_dependencies(${BINARY_NAME} flutter_assemble)
+# Only the install-generated bundle's copy of the executable will launch
+# correctly, since the resources must in the right relative locations. To avoid
+# people trying to run the unbundled copy, put it in a subdirectory instead of
+# the default top-level location.
+set_target_properties(${BINARY_NAME}
+  PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/intermediates_do_not_run"
+)
+
+# Generated plugin build rules, which manage building the plugins and adding
+# them to the application.
+include(flutter/generated_plugins.cmake)
+
+
+# === Installation ===
+# By default, "installing" just makes a relocatable bundle in the build
+# directory.
+set(BUILD_BUNDLE_DIR "${PROJECT_BINARY_DIR}/bundle")
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "${BUILD_BUNDLE_DIR}" CACHE PATH "..." FORCE)
+endif()
+
+# Start with a clean build bundle directory every time.
+install(CODE "
+  file(REMOVE_RECURSE \"${BUILD_BUNDLE_DIR}/\")
+  " COMPONENT Runtime)
+
+set(INSTALL_BUNDLE_DATA_DIR "${CMAKE_INSTALL_PREFIX}/data")
+set(INSTALL_BUNDLE_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+
+install(TARGETS ${BINARY_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_ICU_DATA_FILE}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+  COMPONENT Runtime)
+
+if(PLUGIN_BUNDLED_LIBRARIES)
+  install(FILES "${PLUGIN_BUNDLED_LIBRARIES}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()
+
+# Fully re-copy the assets directory on each build to avoid having stale files
+# from a previous install.
+set(FLUTTER_ASSET_DIR_NAME "flutter_assets")
+install(CODE "
+  file(REMOVE_RECURSE \"${INSTALL_BUNDLE_DATA_DIR}/${FLUTTER_ASSET_DIR_NAME}\")
+  " COMPONENT Runtime)
+install(DIRECTORY "${PROJECT_BUILD_DIR}/${FLUTTER_ASSET_DIR_NAME}"
+  DESTINATION "${INSTALL_BUNDLE_DATA_DIR}" COMPONENT Runtime)
+
+# Install the AOT library on non-Debug builds only.
+if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
+  install(FILES "${AOT_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()

--- a/example/linux/flutter/CMakeLists.txt
+++ b/example/linux/flutter/CMakeLists.txt
@@ -1,0 +1,87 @@
+cmake_minimum_required(VERSION 3.10)
+
+set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
+
+# Configuration provided via flutter tool.
+include(${EPHEMERAL_DIR}/generated_config.cmake)
+
+# TODO: Move the rest of this into files in ephemeral. See
+# https://github.com/flutter/flutter/issues/57146.
+
+# Serves the same purpose as list(TRANSFORM ... PREPEND ...),
+# which isn't available in 3.10.
+function(list_prepend LIST_NAME PREFIX)
+    set(NEW_LIST "")
+    foreach(element ${${LIST_NAME}})
+        list(APPEND NEW_LIST "${PREFIX}${element}")
+    endforeach(element)
+    set(${LIST_NAME} "${NEW_LIST}" PARENT_SCOPE)
+endfunction()
+
+# === Flutter Library ===
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
+pkg_check_modules(GIO REQUIRED IMPORTED_TARGET gio-2.0)
+
+set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/libflutter_linux_gtk.so")
+
+# Published to parent scope for install step.
+set(FLUTTER_LIBRARY ${FLUTTER_LIBRARY} PARENT_SCOPE)
+set(FLUTTER_ICU_DATA_FILE "${EPHEMERAL_DIR}/icudtl.dat" PARENT_SCOPE)
+set(PROJECT_BUILD_DIR "${PROJECT_DIR}/build/" PARENT_SCOPE)
+set(AOT_LIBRARY "${PROJECT_DIR}/build/lib/libapp.so" PARENT_SCOPE)
+
+list(APPEND FLUTTER_LIBRARY_HEADERS
+  "fl_basic_message_channel.h"
+  "fl_binary_codec.h"
+  "fl_binary_messenger.h"
+  "fl_dart_project.h"
+  "fl_engine.h"
+  "fl_json_message_codec.h"
+  "fl_json_method_codec.h"
+  "fl_message_codec.h"
+  "fl_method_call.h"
+  "fl_method_channel.h"
+  "fl_method_codec.h"
+  "fl_method_response.h"
+  "fl_plugin_registrar.h"
+  "fl_plugin_registry.h"
+  "fl_standard_message_codec.h"
+  "fl_standard_method_codec.h"
+  "fl_string_codec.h"
+  "fl_value.h"
+  "fl_view.h"
+  "flutter_linux.h"
+)
+list_prepend(FLUTTER_LIBRARY_HEADERS "${EPHEMERAL_DIR}/flutter_linux/")
+add_library(flutter INTERFACE)
+target_include_directories(flutter INTERFACE
+  "${EPHEMERAL_DIR}"
+)
+target_link_libraries(flutter INTERFACE "${FLUTTER_LIBRARY}")
+target_link_libraries(flutter INTERFACE
+  PkgConfig::GTK
+  PkgConfig::GLIB
+  PkgConfig::GIO
+)
+add_dependencies(flutter flutter_assemble)
+
+# === Flutter tool backend ===
+# _phony_ is a non-existent file to force this command to run every time,
+# since currently there's no way to get a full input/output list from the
+# flutter tool.
+add_custom_command(
+  OUTPUT ${FLUTTER_LIBRARY} ${FLUTTER_LIBRARY_HEADERS}
+    ${CMAKE_CURRENT_BINARY_DIR}/_phony_
+  COMMAND ${CMAKE_COMMAND} -E env
+    ${FLUTTER_TOOL_ENVIRONMENT}
+    "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
+      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+  VERBATIM
+)
+add_custom_target(flutter_assemble DEPENDS
+  "${FLUTTER_LIBRARY}"
+  ${FLUTTER_LIBRARY_HEADERS}
+)

--- a/example/linux/flutter/generated_plugin_registrant.cc
+++ b/example/linux/flutter/generated_plugin_registrant.cc
@@ -1,0 +1,15 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#include "generated_plugin_registrant.h"
+
+#include <native_context_menu/native_context_menu_plugin.h>
+
+void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) native_context_menu_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "NativeContextMenuPlugin");
+  native_context_menu_plugin_register_with_registrar(native_context_menu_registrar);
+}

--- a/example/linux/flutter/generated_plugin_registrant.h
+++ b/example/linux/flutter/generated_plugin_registrant.h
@@ -1,0 +1,15 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#ifndef GENERATED_PLUGIN_REGISTRANT_
+#define GENERATED_PLUGIN_REGISTRANT_
+
+#include <flutter_linux/flutter_linux.h>
+
+// Registers Flutter plugins.
+void fl_register_plugins(FlPluginRegistry* registry);
+
+#endif  // GENERATED_PLUGIN_REGISTRANT_

--- a/example/linux/flutter/generated_plugins.cmake
+++ b/example/linux/flutter/generated_plugins.cmake
@@ -1,0 +1,16 @@
+#
+# Generated file, do not edit.
+#
+
+list(APPEND FLUTTER_PLUGIN_LIST
+  native_context_menu
+)
+
+set(PLUGIN_BUNDLED_LIBRARIES)
+
+foreach(plugin ${FLUTTER_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${plugin}/linux plugins/${plugin})
+  target_link_libraries(${BINARY_NAME} PRIVATE ${plugin}_plugin)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
+endforeach(plugin)

--- a/example/linux/main.cc
+++ b/example/linux/main.cc
@@ -1,0 +1,6 @@
+#include "my_application.h"
+
+int main(int argc, char** argv) {
+  g_autoptr(MyApplication) app = my_application_new();
+  return g_application_run(G_APPLICATION(app), argc, argv);
+}

--- a/example/linux/my_application.cc
+++ b/example/linux/my_application.cc
@@ -1,0 +1,104 @@
+#include "my_application.h"
+
+#include <flutter_linux/flutter_linux.h>
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
+#endif
+
+#include "flutter/generated_plugin_registrant.h"
+
+struct _MyApplication {
+  GtkApplication parent_instance;
+  char** dart_entrypoint_arguments;
+};
+
+G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
+
+// Implements GApplication::activate.
+static void my_application_activate(GApplication* application) {
+  MyApplication* self = MY_APPLICATION(application);
+  GtkWindow* window =
+      GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
+
+  // Use a header bar when running in GNOME as this is the common style used
+  // by applications and is the setup most users will be using (e.g. Ubuntu
+  // desktop).
+  // If running on X and not using GNOME then just use a traditional title bar
+  // in case the window manager does more exotic layout, e.g. tiling.
+  // If running on Wayland assume the header bar will work (may need changing
+  // if future cases occur).
+  gboolean use_header_bar = TRUE;
+#ifdef GDK_WINDOWING_X11
+  GdkScreen* screen = gtk_window_get_screen(window);
+  if (GDK_IS_X11_SCREEN(screen)) {
+    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
+    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
+      use_header_bar = FALSE;
+    }
+  }
+#endif
+  if (use_header_bar) {
+    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
+    gtk_widget_show(GTK_WIDGET(header_bar));
+    gtk_header_bar_set_title(header_bar, "native_context_menu_example");
+    gtk_header_bar_set_show_close_button(header_bar, TRUE);
+    gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
+  } else {
+    gtk_window_set_title(window, "native_context_menu_example");
+  }
+
+  gtk_window_set_default_size(window, 1280, 720);
+  gtk_widget_show(GTK_WIDGET(window));
+
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  fl_dart_project_set_dart_entrypoint_arguments(project, self->dart_entrypoint_arguments);
+
+  FlView* view = fl_view_new(project);
+  gtk_widget_show(GTK_WIDGET(view));
+  gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
+
+  fl_register_plugins(FL_PLUGIN_REGISTRY(view));
+
+  gtk_widget_grab_focus(GTK_WIDGET(view));
+}
+
+// Implements GApplication::local_command_line.
+static gboolean my_application_local_command_line(GApplication* application, gchar*** arguments, int* exit_status) {
+  MyApplication* self = MY_APPLICATION(application);
+  // Strip out the first argument as it is the binary name.
+  self->dart_entrypoint_arguments = g_strdupv(*arguments + 1);
+
+  g_autoptr(GError) error = nullptr;
+  if (!g_application_register(application, nullptr, &error)) {
+     g_warning("Failed to register: %s", error->message);
+     *exit_status = 1;
+     return TRUE;
+  }
+
+  g_application_activate(application);
+  *exit_status = 0;
+
+  return TRUE;
+}
+
+// Implements GObject::dispose.
+static void my_application_dispose(GObject* object) {
+  MyApplication* self = MY_APPLICATION(object);
+  g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
+  G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
+}
+
+static void my_application_class_init(MyApplicationClass* klass) {
+  G_APPLICATION_CLASS(klass)->activate = my_application_activate;
+  G_APPLICATION_CLASS(klass)->local_command_line = my_application_local_command_line;
+  G_OBJECT_CLASS(klass)->dispose = my_application_dispose;
+}
+
+static void my_application_init(MyApplication* self) {}
+
+MyApplication* my_application_new() {
+  return MY_APPLICATION(g_object_new(my_application_get_type(),
+                                     "application-id", APPLICATION_ID,
+                                     "flags", G_APPLICATION_NON_UNIQUE,
+                                     nullptr));
+}

--- a/example/linux/my_application.h
+++ b/example/linux/my_application.h
@@ -1,0 +1,18 @@
+#ifndef FLUTTER_MY_APPLICATION_H_
+#define FLUTTER_MY_APPLICATION_H_
+
+#include <gtk/gtk.h>
+
+G_DECLARE_FINAL_TYPE(MyApplication, my_application, MY, APPLICATION,
+                     GtkApplication)
+
+/**
+ * my_application_new:
+ *
+ * Creates a new Flutter-based application.
+ *
+ * Returns: a new #MyApplication.
+ */
+MyApplication* my_application_new();
+
+#endif  // FLUTTER_MY_APPLICATION_H_

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -87,7 +87,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -155,7 +155,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/context_menu_region.dart
+++ b/lib/src/context_menu_region.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 
@@ -28,6 +30,8 @@ class _ContextMenuRegionState extends State<ContextMenuRegion> {
 
   @override
   Widget build(BuildContext context) {
+    final mq = MediaQuery.of(context);
+
     return Listener(
       onPointerDown: (e) {
         shouldReact = e.kind == PointerDeviceKind.mouse &&
@@ -38,9 +42,15 @@ class _ContextMenuRegionState extends State<ContextMenuRegion> {
 
         shouldReact = false;
 
+        double y = e.position.dy;
+
+        if (Platform.isMacOS) {
+          y = mq.size.height - y;
+        }
+
         final position = Offset(
           e.position.dx + widget.menuOffset.dx,
-          e.position.dy + widget.menuOffset.dy,
+          y + widget.menuOffset.dy,
         );
 
         final selectedItem = await showContextMenu(

--- a/lib/src/method_channel.dart
+++ b/lib/src/method_channel.dart
@@ -1,8 +1,22 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/services.dart' show MethodChannel, EventChannel;
 import 'package:flutter/widgets.dart' show Offset, VoidCallback;
+
+/// Method channel name of the plugin.
+const String _kChannelName = 'native_context_menu';
+
+/// Show menu call.
+/// Shows context menu at passed position or cursor position.
+/// Pass `devicePixelRatio` and `position` from Dart to show menu at specified position.
+/// If it is not defined, native code will show the context menu at the cursor's position.
+const String _kShowMenu = "showMenu";
+
+/// Called when an item is selected from the context menu.
+const String _kOnItemSelected = "onItemSelected";
+
+/// Called when menu is dismissed without clicking any item.
+const String _kOnMenuDismissed = "onMenuDismissed";
 
 class MenuItem {
   late int _id;
@@ -40,43 +54,55 @@ class ShowMenuArgs {
   Map<String, dynamic> toJson() {
     return {
       'devicePixelRatio': devicePixelRatio,
-      'position': [position.dx, position.dy],
+      'position': <double>[position.dx, position.dy],
       'items': items.map((e) => e.toJson()).toList(),
     };
   }
 }
 
-final _channel = const MethodChannel('native_context_menu')
+final _channel = const MethodChannel(_kChannelName)
   ..setMethodCallHandler(
     (call) async {
       switch (call.method) {
-        case 'id':
+        case _kOnItemSelected:
           {
-            // Notify about the selected menu item's id & complete the future.
-            _completer.complete(call.arguments);
+            _contextMenuCompleter.complete(call.arguments);
+            break;
+          }
+        case _kOnMenuDismissed:
+          {
+            _contextMenuCompleter.complete(null);
             break;
           }
         default:
-          break;
+          {
+            _contextMenuCompleter.completeError(
+              Exception('$_kChannelName: Invalid method call received.'),
+            );
+          }
       }
     },
   );
-Completer<int> _completer = Completer<int>();
+
+Completer<int?> _contextMenuCompleter = Completer<int?>();
+
 int _menuItemId = 0;
 
 Future<MenuItem?> showContextMenu(ShowMenuArgs args) async {
   final menu = _buildMenu(args.items);
   _menuItemId = 0;
-  _channel.invokeMethod('showMenu', args.toJson());
-  int id = await _completer.future;
-  _completer = Completer<int>();
-  if (id != -1) {
-    return menu[id];
-  }
+
+  _channel.invokeMethod(_kShowMenu, args.toJson());
+
+  final id = await _contextMenuCompleter.future;
+  _contextMenuCompleter = Completer<int?>();
+
+  return menu[id];
 }
 
 Map<int, MenuItem> _buildMenu(List<MenuItem> items) {
   final built = <int, MenuItem>{};
+
   for (var item in items) {
     item._id = _menuItemId++;
     built[item._id] = item;

--- a/linux/.clang-format
+++ b/linux/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Google
+DerivePointerAlignment: false
+PointerAlignment: Left

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.10)
+set(PROJECT_NAME "native_context_menu")
+project(${PROJECT_NAME} LANGUAGES CXX)
+
+# This value is used when generating builds using this plugin, so it must
+# not be changed
+set(PLUGIN_NAME "native_context_menu_plugin")
+
+add_library(${PLUGIN_NAME} SHARED
+  "native_context_menu_plugin.cc"
+)
+apply_standard_settings(${PLUGIN_NAME})
+set_target_properties(${PLUGIN_NAME} PROPERTIES
+  CXX_VISIBILITY_PRESET hidden)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+target_include_directories(${PLUGIN_NAME} INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
+target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
+
+# List of absolute paths to libraries that should be bundled with the plugin
+set(native_context_menu_bundled_libraries
+  ""
+  PARENT_SCOPE
+)

--- a/linux/include/native_context_menu/native_context_menu_plugin.h
+++ b/linux/include/native_context_menu/native_context_menu_plugin.h
@@ -1,0 +1,26 @@
+#ifndef FLUTTER_PLUGIN_NATIVE_CONTEXT_MENU_PLUGIN_H_
+#define FLUTTER_PLUGIN_NATIVE_CONTEXT_MENU_PLUGIN_H_
+
+#include <flutter_linux/flutter_linux.h>
+
+G_BEGIN_DECLS
+
+#ifdef FLUTTER_PLUGIN_IMPL
+#define FLUTTER_PLUGIN_EXPORT __attribute__((visibility("default")))
+#else
+#define FLUTTER_PLUGIN_EXPORT
+#endif
+
+typedef struct _NativeContextMenuPlugin NativeContextMenuPlugin;
+typedef struct {
+  GObjectClass parent_class;
+} NativeContextMenuPluginClass;
+
+FLUTTER_PLUGIN_EXPORT GType native_context_menu_plugin_get_type();
+
+FLUTTER_PLUGIN_EXPORT void native_context_menu_plugin_register_with_registrar(
+    FlPluginRegistrar* registrar);
+
+G_END_DECLS
+
+#endif  // FLUTTER_PLUGIN_NATIVE_CONTEXT_MENU_PLUGIN_H_

--- a/linux/native_context_menu_plugin.cc
+++ b/linux/native_context_menu_plugin.cc
@@ -2,38 +2,202 @@
 
 #include <flutter_linux/flutter_linux.h>
 #include <gtk/gtk.h>
-#include <sys/utsname.h>
 
 #include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
 
 #define NATIVE_CONTEXT_MENU_PLUGIN(obj)                                     \
   (G_TYPE_CHECK_INSTANCE_CAST((obj), native_context_menu_plugin_get_type(), \
                               NativeContextMenuPlugin))
 
+// Platform channel name.
+constexpr auto kChannelName = "native_context_menu";
+// Show menu call.
+constexpr auto kShowMenu = "showMenu";
+
+NativeContextMenuPlugin* g_plugin;
+
+// Represents a menu item, stores its id, title & possible sub-menu items.
+class MenuItem;
+
+class MenuItem {
+ public:
+  auto id_ptr() const { return &id_; }
+  int32_t id() const { return id_; }
+  std::string& title() { return title_; }
+  std::vector<std::unique_ptr<MenuItem>>& items() { return items_; }
+
+  MenuItem(int32_t id, const char* title) : id_(id), title_(title) {}
+
+ private:
+  int32_t id_ = -1;
+  std::string title_ = "";
+  std::vector<std::unique_ptr<MenuItem>> items_ = {};
+};
+
 struct _NativeContextMenuPlugin {
   GObject parent_instance;
+  FlPluginRegistrar* registrar;
+  FlMethodChannel* channel;
+  // Saving `MenuItem` objects in `std::vector` so that they do not get
+  // deallocated from memory once the method call is finished (to avoid
+  // SEGFAULT).
+  // Previously created `MenuItem`s are automatically freed upon each call by
+  // calling `std::vector::clear` before each call. Thanks to smart pointers.
+  std::vector<std::unique_ptr<MenuItem>> last_menu_items = {};
+  bool last_menu_item_selected = false;
+  // A separated thread to send "deactivate" signal with `id` as -1 since it is
+  // called before "active" on any of menu items. Freed before each subsequent
+  // call.
+  std::unique_ptr<std::thread> last_menu_thread = nullptr;
 };
 
 G_DEFINE_TYPE(NativeContextMenuPlugin, native_context_menu_plugin,
               g_object_get_type())
 
-// Called when a method call is received from Flutter.
+// Called when a menu item is clicked.
+static inline void on_menu_item_clicked(GtkWidget* widget, gpointer data) {
+  // Pressed menu item.
+  g_plugin->last_menu_item_selected = true;
+  auto menu_item = static_cast<MenuItem*>(data);
+  fl_method_channel_invoke_method(g_plugin->channel, "id",
+                                  fl_value_new_int(menu_item->id()), nullptr,
+                                  nullptr, nullptr);
+}
+
+// Called when a menu is deactivated.
+static inline void on_menu_deactivated(GtkWidget* widget, gpointer) {
+  // TODO: Currently using "deactivate" signal to detect menu being dismissed by
+  // user.
+  // Problem: "deactivate" signal is sent regardless whether menu item was
+  // clicked or not (and leads the "activate" event). To notify about "activate"
+  // signal first, this thread is put to sleep (so that "activate" event is
+  // notified first). A better signal in GTK might be present which can be used
+  // to avoid this scenario.
+  g_plugin->last_menu_thread.reset(new std::thread([=]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    if (!g_plugin->last_menu_item_selected)
+      fl_method_channel_invoke_method(g_plugin->channel, "id",
+                                      fl_value_new_int(-1), nullptr, nullptr,
+                                      nullptr);
+  }));
+}
+
+// Gets the parent `GdkWindow` to show the context menu in it.
+static inline GdkWindow* get_window(NativeContextMenuPlugin* self) {
+  FlView* view = fl_plugin_registrar_get_view(self->registrar);
+  if (view == nullptr) return nullptr;
+
+  return gtk_widget_get_window(gtk_widget_get_toplevel(GTK_WIDGET(view)));
+}
+
 static void native_context_menu_plugin_handle_method_call(
     NativeContextMenuPlugin* self, FlMethodCall* method_call) {
   g_autoptr(FlMethodResponse) response = nullptr;
-
   const gchar* method = fl_method_call_get_name(method_call);
+  if (strcmp(method, kShowMenu) == 0) {
+    // Clear previously saved object instances.
+    self->last_menu_items.clear();
+    self->last_menu_item_selected = false;
+    if (self->last_menu_thread != nullptr) {
+      self->last_menu_thread->detach();
+      self->last_menu_thread.reset(nullptr);
+    }
+    auto arguments = fl_method_call_get_args(method_call);
+    auto items = fl_value_lookup_string(arguments, "items");
+    GdkWindow* window = get_window(self);
+    GtkWidget* menu = gtk_menu_new();
+    for (int32_t i = 0; i < fl_value_get_length(items); i++) {
+      int32_t id = fl_value_get_int(
+          fl_value_lookup_string(fl_value_get_list_value(items, i), "id"));
+      const char* title = fl_value_get_string(
+          fl_value_lookup_string(fl_value_get_list_value(items, i), "title"));
+      auto sub_items =
+          fl_value_lookup_string(fl_value_get_list_value(items, i), "items");
+      self->last_menu_items.emplace_back(std::make_unique<MenuItem>(id, title));
+      GtkWidget* menu_item = gtk_menu_item_new_with_label(title);
+      // Check for sub-items & create a sub-menu.
+      if (fl_value_get_length(sub_items) > 0) {
+        GtkWidget* sub_menu = gtk_menu_new();
+        for (int32_t j = 0; j < fl_value_get_length(sub_items); j++) {
+          int32_t sub_id = fl_value_get_int(fl_value_lookup_string(
+              fl_value_get_list_value(sub_items, j), "id"));
+          const char* sub_title = fl_value_get_string(fl_value_lookup_string(
+              fl_value_get_list_value(sub_items, j), "title"));
+          GtkWidget* sub_menu_item = gtk_menu_item_new_with_label(sub_title);
+          gtk_menu_shell_append(GTK_MENU_SHELL(sub_menu), sub_menu_item);
+          gtk_widget_show(sub_menu_item);
+          self->last_menu_items.back()->items().emplace_back(
+              std::make_unique<MenuItem>(sub_id, sub_title));
+          g_signal_connect(
+              G_OBJECT(sub_menu_item), "activate",
+              G_CALLBACK(on_menu_item_clicked),
+              (gpointer)self->last_menu_items.back()->items().at(j).get());
+        }
+        gtk_menu_item_set_submenu(GTK_MENU_ITEM(menu_item), sub_menu);
+      } else {
+        // Avoid "activate" event for the menu item containing a sub-menu.
+        g_signal_connect(G_OBJECT(menu_item), "activate",
+                         G_CALLBACK(on_menu_item_clicked),
+                         (gpointer)self->last_menu_items.back().get());
+      }
+      gtk_widget_show(menu_item);
+      gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_item);
+    }
+    GdkRectangle rectangle;
+    // Define USE_FLUTTER_POSITION to use `devicePixelRatio` and `position` from
+    // Dart. If it is not defined, GTK will calculate the mouse position & show
+    // the context menu accordingly.
+    // It is recommended to not use it since it can cause problem on Wayland.
+#ifdef USE_FLUTTER_POSITION
+    auto device_pixel_ratio =
+        fl_value_lookup_string(arguments, "devicePixelRatio");
+    auto position = fl_value_lookup_string(arguments, "position");
+    rectangle.x = fl_value_get_float(fl_value_get_list_value(position, 0)) *
+                  fl_value_get_float(device_pixel_ratio);
+    rectangle.y = fl_value_get_float(fl_value_get_list_value(position, 1)) *
+                  fl_value_get_float(device_pixel_ratio);
+#else
+    GdkDevice* mouse_device;
+    int x, y;
+    // Legacy support.
+#if GTK_CHECK_VERSION(3, 20, 0)
+    GdkSeat* seat = gdk_display_get_default_seat(gdk_display_get_default());
+    mouse_device = gdk_seat_get_pointer(seat);
+#else
+    GdkDeviceManager* devman =
+        gdk_display_get_device_manager(gdk_display_get_default());
+    mouse_device = gdk_device_manager_get_client_pointer(devman);
+#endif
+    gdk_window_get_device_position(window, mouse_device, &x, &y, NULL);
+    rectangle.x = x;
+    rectangle.y = y;
+#endif
+    g_signal_connect(G_OBJECT(menu), "deactivate",
+                     G_CALLBACK(on_menu_deactivated), nullptr);
+    // `gtk_menu_popup_at_rect` is used since `gtk_menu_popup_at_pointer` will
+    // require event box creation & another callback will be involved. This way
+    // is straight forward & easy to work with.
+    // NOTE: GDK_GRAVITY_NORTH_WEST is hard-coded by default since no analog is
+    // present for it inside the Dart platform channel code (as of now). In
+    // summary, this will create a menu whose body is in bottom-right to the
+    // position of the mouse pointer.
+    gtk_menu_popup_at_rect(GTK_MENU(menu), window, &rectangle,
+                           GDK_GRAVITY_NORTH_WEST, GDK_GRAVITY_NORTH_WEST,
+                           NULL);
 
-  if (strcmp(method, "getPlatformVersion") == 0) {
-    struct utsname uname_data = {};
-    uname(&uname_data);
-    g_autofree gchar* version = g_strdup_printf("Linux %s", uname_data.version);
-    g_autoptr(FlValue) result = fl_value_new_string(version);
-    response = FL_METHOD_RESPONSE(fl_method_success_response_new(result));
+    // Responding with `null`, click event & respective `id` of the `MenuItem`
+    // is notified through callback. Otherwise the GUI will become unresponsive.
+    // To keep the API same, a `Completer` is used in the Dart.
+    response =
+        FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   } else {
     response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
   }
-
   fl_method_call_respond(method_call, response, nullptr);
 }
 
@@ -53,18 +217,22 @@ static void method_call_cb(FlMethodChannel* channel, FlMethodCall* method_call,
   NativeContextMenuPlugin* plugin = NATIVE_CONTEXT_MENU_PLUGIN(user_data);
   native_context_menu_plugin_handle_method_call(plugin, method_call);
 }
+NativeContextMenuPlugin* native_context_menu_plugin_new(
+    FlPluginRegistrar* registrar) {
+  NativeContextMenuPlugin* self = NATIVE_CONTEXT_MENU_PLUGIN(
+      g_object_new(native_context_menu_plugin_get_type(), nullptr));
+  self->registrar = FL_PLUGIN_REGISTRAR(g_object_ref(registrar));
+  g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
+  self->channel =
+      fl_method_channel_new(fl_plugin_registrar_get_messenger(registrar),
+                            kChannelName, FL_METHOD_CODEC(codec));
+  fl_method_channel_set_method_call_handler(self->channel, method_call_cb,
+                                            g_object_ref(self), g_object_unref);
+  return self;
+}
 
 void native_context_menu_plugin_register_with_registrar(
     FlPluginRegistrar* registrar) {
-  NativeContextMenuPlugin* plugin = NATIVE_CONTEXT_MENU_PLUGIN(
-      g_object_new(native_context_menu_plugin_get_type(), nullptr));
-
-  g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
-  g_autoptr(FlMethodChannel) channel =
-      fl_method_channel_new(fl_plugin_registrar_get_messenger(registrar),
-                            "native_context_menu", FL_METHOD_CODEC(codec));
-  fl_method_channel_set_method_call_handler(
-      channel, method_call_cb, g_object_ref(plugin), g_object_unref);
-
-  g_object_unref(plugin);
+  g_plugin = native_context_menu_plugin_new(registrar);
+  g_object_unref(g_plugin);
 }

--- a/linux/native_context_menu_plugin.cc
+++ b/linux/native_context_menu_plugin.cc
@@ -1,0 +1,70 @@
+#include "include/native_context_menu/native_context_menu_plugin.h"
+
+#include <flutter_linux/flutter_linux.h>
+#include <gtk/gtk.h>
+#include <sys/utsname.h>
+
+#include <cstring>
+
+#define NATIVE_CONTEXT_MENU_PLUGIN(obj)                                     \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj), native_context_menu_plugin_get_type(), \
+                              NativeContextMenuPlugin))
+
+struct _NativeContextMenuPlugin {
+  GObject parent_instance;
+};
+
+G_DEFINE_TYPE(NativeContextMenuPlugin, native_context_menu_plugin,
+              g_object_get_type())
+
+// Called when a method call is received from Flutter.
+static void native_context_menu_plugin_handle_method_call(
+    NativeContextMenuPlugin* self, FlMethodCall* method_call) {
+  g_autoptr(FlMethodResponse) response = nullptr;
+
+  const gchar* method = fl_method_call_get_name(method_call);
+
+  if (strcmp(method, "getPlatformVersion") == 0) {
+    struct utsname uname_data = {};
+    uname(&uname_data);
+    g_autofree gchar* version = g_strdup_printf("Linux %s", uname_data.version);
+    g_autoptr(FlValue) result = fl_value_new_string(version);
+    response = FL_METHOD_RESPONSE(fl_method_success_response_new(result));
+  } else {
+    response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
+  }
+
+  fl_method_call_respond(method_call, response, nullptr);
+}
+
+static void native_context_menu_plugin_dispose(GObject* object) {
+  G_OBJECT_CLASS(native_context_menu_plugin_parent_class)->dispose(object);
+}
+
+static void native_context_menu_plugin_class_init(
+    NativeContextMenuPluginClass* klass) {
+  G_OBJECT_CLASS(klass)->dispose = native_context_menu_plugin_dispose;
+}
+
+static void native_context_menu_plugin_init(NativeContextMenuPlugin* self) {}
+
+static void method_call_cb(FlMethodChannel* channel, FlMethodCall* method_call,
+                           gpointer user_data) {
+  NativeContextMenuPlugin* plugin = NATIVE_CONTEXT_MENU_PLUGIN(user_data);
+  native_context_menu_plugin_handle_method_call(plugin, method_call);
+}
+
+void native_context_menu_plugin_register_with_registrar(
+    FlPluginRegistrar* registrar) {
+  NativeContextMenuPlugin* plugin = NATIVE_CONTEXT_MENU_PLUGIN(
+      g_object_new(native_context_menu_plugin_get_type(), nullptr));
+
+  g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
+  g_autoptr(FlMethodChannel) channel =
+      fl_method_channel_new(fl_plugin_registrar_get_messenger(registrar),
+                            "native_context_menu", FL_METHOD_CODEC(codec));
+  fl_method_channel_set_method_call_handler(
+      channel, method_call_cb, g_object_ref(plugin), g_object_unref);
+
+  g_object_unref(plugin);
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -80,7 +80,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,8 @@ flutter:
         pluginClass: NativeContextMenuPlugin
       windows:
         pluginClass: NativeContextMenuPlugin
+      linux:
+        pluginClass: NativeContextMenuPlugin
 
   # To add assets to your plugin package, add an assets section, like this:
   # assets:

--- a/windows/.clang-format
+++ b/windows/.clang-format
@@ -1,1 +1,3 @@
-BasedOnStyle: Microsoft
+BasedOnStyle: Google
+DerivePointerAlignment: false
+PointerAlignment: Left

--- a/windows/native_context_menu_plugin.cpp
+++ b/windows/native_context_menu_plugin.cpp
@@ -1,205 +1,199 @@
 #include "include/native_context_menu/native_context_menu_plugin.h"
 
-// This must be included before many other Windows headers.
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>
 #include <flutter/standard_method_codec.h>
-#include <windows.h>
 
 #include <codecvt>
 #include <future>
 #include <map>
 #include <memory>
-#include <sstream>
 
-namespace
-{
-std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> last_show_menu_result;
-bool last_show_menu_responded = false;
+#include <WinUser.h>
 
-class NativeContextMenuPlugin : public flutter::Plugin
-{
-  public:
-    static void RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar);
+// Platform channel name.
+constexpr auto kChannelName = "native_context_menu";
+// Show menu call.
+constexpr auto kShowMenu = "showMenu";
 
-    NativeContextMenuPlugin(flutter::PluginRegistrarWindows *registrar);
+namespace {
 
-    virtual ~NativeContextMenuPlugin();
+class NativeContextMenuPlugin : public flutter::Plugin {
+ public:
+  static void RegisterWithRegistrar(flutter::PluginRegistrarWindows* registrar);
 
-  private:
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> g_converter;
+  NativeContextMenuPlugin(
+      flutter::PluginRegistrarWindows* registrar,
+      std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel);
 
-    flutter::PluginRegistrarWindows *registrar;
-    // The ID of the WindowProc delegate registration.
-    int window_proc_id = -1;
+  virtual ~NativeContextMenuPlugin();
 
-    HMENU hMenu;
+ private:
+  flutter::PluginRegistrarWindows* registrar_ = nullptr;
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel_ =
+      nullptr;
+  HMENU menu_handle_ = nullptr;
+  int32_t window_proc_id_ = -1;
+  // Windows sends `WM_EXITMENULOOP` message even if a menu item is selected
+  // before `WM_COMMAND`. For responding Dart the `id` of the selected menu item
+  // before the -1, this thread adds slight delay to `WM_EXITMENULOOP`. Freed
+  // after each subsequent call.
+  std::unique_ptr<std::thread> last_menu_thread_ = nullptr;
+  bool last_menu_item_selected_ = false;
+  // For safe conversion between `wchar_t[]` and `char[]`.
+  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter_;
 
-    // Called for top-level WindowProc delegation.
-    std::optional<LRESULT> NativeContextMenuPlugin::HandleWindowProc(HWND hwnd, UINT message, WPARAM wparam,
-                                                                     LPARAM lparam);
-    HWND NativeContextMenuPlugin::GetMainWindow();
-    void NativeContextMenuPlugin::CreateMenu(HMENU menu, flutter::EncodableMap args);
-    void NativeContextMenuPlugin::ShowMenu(const flutter::MethodCall<flutter::EncodableValue> &method_call,
-                                           std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+  std::optional<LRESULT> HandleWindowProc(HWND hwnd, UINT message,
+                                          WPARAM wparam, LPARAM lparam);
+  HWND GetWindow();
 
-    // Called when a method is called on this plugin's channel from Dart.
-    void HandleMethodCall(const flutter::MethodCall<flutter::EncodableValue> &method_call,
-                          std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+  void CreateMenu(HMENU menu, flutter::EncodableMap arguments);
+
+  void HandleMethodCall(
+      const flutter::MethodCall<flutter::EncodableValue>& method_call,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
 };
 
-// static
-void NativeContextMenuPlugin::RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar)
-{
-    auto channel = std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
-        registrar->messenger(), "native_context_menu", &flutter::StandardMethodCodec::GetInstance());
-
-    auto plugin = std::make_unique<NativeContextMenuPlugin>(registrar);
-
-    channel->SetMethodCallHandler([plugin_pointer = plugin.get()](const auto &call, auto result) {
-        plugin_pointer->HandleMethodCall(call, std::move(result));
-    });
-
-    registrar->AddPlugin(std::move(plugin));
+void NativeContextMenuPlugin::RegisterWithRegistrar(
+    flutter::PluginRegistrarWindows* registrar) {
+  auto plugin = std::make_unique<NativeContextMenuPlugin>(
+      registrar,
+      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+          registrar->messenger(), kChannelName,
+          &flutter::StandardMethodCodec::GetInstance()));
+  registrar->AddPlugin(std::move(plugin));
 }
 
-NativeContextMenuPlugin::NativeContextMenuPlugin(flutter::PluginRegistrarWindows *registrar) : registrar(registrar)
-{
-    window_proc_id =
-        registrar->RegisterTopLevelWindowProcDelegate([this](HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam) {
-            return HandleWindowProc(hwnd, message, wparam, lparam);
-        });
+NativeContextMenuPlugin::NativeContextMenuPlugin(
+    flutter::PluginRegistrarWindows* registrar,
+    std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel)
+    : registrar_(registrar), channel_(std::move(channel)) {
+  channel_->SetMethodCallHandler([=](const auto& call, auto result) {
+    HandleMethodCall(call, std::move(result));
+  });
+  window_proc_id_ = registrar->RegisterTopLevelWindowProcDelegate(
+      [this](HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam) {
+        return HandleWindowProc(hwnd, message, wparam, lparam);
+      });
 }
 
-NativeContextMenuPlugin::~NativeContextMenuPlugin()
-{
-    registrar->UnregisterTopLevelWindowProcDelegate(window_proc_id);
+NativeContextMenuPlugin::~NativeContextMenuPlugin() {
+  // Delete possibly created thread before exit.
+  if (last_menu_thread_ != nullptr) {
+    last_menu_thread_->detach();
+    last_menu_thread_.reset(nullptr);
+  }
+  registrar_->UnregisterTopLevelWindowProcDelegate(window_proc_id_);
 }
 
-void HandlePopupMenuClickItem(const int item_id)
-{
-    if (!last_show_menu_responded)
-    {
-        last_show_menu_responded = true;
-        last_show_menu_result->Success(flutter::EncodableValue(item_id));
+std::optional<LRESULT> NativeContextMenuPlugin::HandleWindowProc(
+    HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam) {
+  switch (message) {
+    case WM_COMMAND: {
+      last_menu_item_selected_ = true;
+      channel_->InvokeMethod("id", std::make_unique<flutter::EncodableValue>(
+                                       static_cast<int32_t>(wparam)));
+      break;
     }
-}
-
-void HandlePopupMenuDismissed(const int item_id)
-{
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    if (!last_show_menu_responded)
-    {
-        last_show_menu_responded = true;
-        last_show_menu_result->Success(flutter::EncodableValue(item_id));
-    }
-}
-
-std::optional<LRESULT> NativeContextMenuPlugin::HandleWindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
-{
-    std::optional<LRESULT> result;
-    if (message == WM_COMMAND)
-    {
-        int item_id = (int)wParam;
-        std::thread th(HandlePopupMenuClickItem, item_id);
-        th.detach();
-    }
-    else if (message == WM_EXITMENULOOP)
-    {
-        int item_id = -1;
-        std::thread th(HandlePopupMenuDismissed, item_id);
-        th.detach();
-    }
-    return result;
-}
-
-HWND NativeContextMenuPlugin::GetMainWindow()
-{
-    return ::GetAncestor(registrar->GetView()->GetNativeWindow(), GA_ROOT);
-}
-
-void NativeContextMenuPlugin::CreateMenu(HMENU menu, flutter::EncodableMap args)
-{
-    flutter::EncodableList items = std::get<flutter::EncodableList>(args.at(flutter::EncodableValue("items")));
-
-    int count = GetMenuItemCount(menu);
-    for (int i = 0; i < count; i++)
-    {
-        // always remove at 0 because they shift every time
-        RemoveMenu(menu, 0, MF_BYPOSITION);
-    }
-
-    for (flutter::EncodableValue item_value : items)
-    {
-        flutter::EncodableMap item_map = std::get<flutter::EncodableMap>(item_value);
-        int id = std::get<int>(item_map.at(flutter::EncodableValue("id")));
-        std::string title = std::get<std::string>(item_map.at(flutter::EncodableValue("title")));
-
-        UINT_PTR item_id = id;
-        UINT uFlags = MF_STRING;
-
-        flutter::EncodableList sub_items =
-            std::get<flutter::EncodableList>(item_map.at(flutter::EncodableValue("items")));
-
-        if (sub_items.size() > 0)
-        {
-            uFlags |= MF_POPUP;
-            HMENU sub_menu = ::CreatePopupMenu();
-            CreateMenu(sub_menu, item_map);
-            item_id = reinterpret_cast<UINT_PTR>(sub_menu);
+    case WM_EXITMENULOOP: {
+      last_menu_thread_ = std::make_unique<std::thread>([=] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        if (!last_menu_item_selected_) {
+          channel_->InvokeMethod("id",
+                                 std::make_unique<flutter::EncodableValue>(-1));
         }
-
-        AppendMenuW(menu, uFlags, item_id, g_converter.from_bytes(title).c_str());
+      });
+      break;
     }
+    default:
+      break;
+  }
+  return std::nullopt;
 }
 
-void NativeContextMenuPlugin::ShowMenu(const flutter::MethodCall<flutter::EncodableValue> &method_call,
-                                       std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result)
-{
-    const flutter::EncodableMap &args = std::get<flutter::EncodableMap>(*method_call.arguments());
+HWND NativeContextMenuPlugin::GetWindow() {
+  return ::GetAncestor(registrar_->GetView()->GetNativeWindow(), GA_ROOT);
+}
 
-    double device_pixel_patio = std::get<double>(args.at(flutter::EncodableValue("devicePixelRatio")));
-    const flutter::EncodableList pos = std::get<flutter::EncodableList>(args.at(flutter::EncodableValue("position")));
+void NativeContextMenuPlugin::CreateMenu(HMENU menu,
+                                         flutter::EncodableMap arguments) {
+  auto items = std::get<flutter::EncodableList>(
+      arguments[flutter::EncodableValue("items")]);
+  int32_t count = ::GetMenuItemCount(menu);
+  for (int32_t i = 0; i < count; i++) {
+    // Always remove at 0 because they shift every time.
+    ::RemoveMenu(menu, 0, MF_BYPOSITION);
+  }
+  for (const auto& item_value : items) {
+    auto item = std::get<flutter::EncodableMap>(item_value);
+    int32_t id = std::get<int32_t>(item[flutter::EncodableValue("id")]);
+    auto title = std::get<std::string>(item[flutter::EncodableValue("title")]);
+    UINT_PTR item_id = id;
+    UINT uFlags = MF_STRING;
+    auto sub_items = std::get<flutter::EncodableList>(
+        item[flutter::EncodableValue("items")]);
+    if (sub_items.size() > 0) {
+      uFlags |= MF_POPUP;
+      HMENU sub_menu = ::CreatePopupMenu();
+      CreateMenu(sub_menu, item);
+      item_id = reinterpret_cast<UINT_PTR>(sub_menu);
+    }
+    ::AppendMenuW(menu, uFlags, item_id, converter_.from_bytes(title).c_str());
+  }
+}
 
-    hMenu = CreatePopupMenu();
-    CreateMenu(hMenu, args);
-
-    HWND hWnd = GetMainWindow();
-
+void NativeContextMenuPlugin::HandleMethodCall(
+    const flutter::MethodCall<flutter::EncodableValue>& method_call,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+  if (method_call.method_name().compare(kShowMenu) == 0) {
+    last_menu_item_selected_ = false;
+    if (last_menu_thread_ != nullptr) {
+      last_menu_thread_->detach();
+      last_menu_thread_.reset(nullptr);
+    }
+    auto arguments = std::get<flutter::EncodableMap>(*method_call.arguments());
+    menu_handle_ = CreatePopupMenu();
+    CreateMenu(menu_handle_, arguments);
+    HWND window = GetWindow();
     RECT rect;
-    GetWindowRect(hWnd, &rect);
-
-    TITLEBARINFOEX *ptinfo = (TITLEBARINFOEX *)malloc(sizeof(TITLEBARINFOEX));
-    ptinfo->cbSize = sizeof(TITLEBARINFOEX);
-    SendMessage(hWnd, WM_GETTITLEBARINFOEX, 0, (LPARAM)ptinfo);
-    int titleBarHeight = ptinfo->rcTitleBar.bottom - ptinfo->rcTitleBar.top;
-
-    int x = static_cast<int>((std::get<double>(pos[0]) * device_pixel_patio) + rect.left);
-    int y = static_cast<int>((std::get<double>(pos[1]) * device_pixel_patio) + rect.top + titleBarHeight);
-
-    last_show_menu_result = std::move(result);
-    last_show_menu_responded = false;
-
-    TrackPopupMenu(hMenu, TPM_LEFTALIGN | TPM_LEFTBUTTON, static_cast<int>(x), static_cast<int>(y), 0, hWnd, NULL);
+    ::GetWindowRect(window, &rect);
+// Define USE_FLUTTER_POSITION to use `devicePixelRatio` and `position` from
+// Dart. If it is not defined, WIN32 will use `GetCursorPos` to show the context
+// menu at the mouse's position.
+#ifdef USE_FLUTTER_POSITION
+    auto device_pixel_patio = std::get<double>(
+        arguments[flutter::EncodableValue("devicePixelRatio")]);
+    auto position = std::get<flutter::EncodableList>(
+        arguments[flutter::EncodableValue("position")]);
+    TITLEBARINFOEX title_bar_info;
+    title_bar_info.cbSize = sizeof(TITLEBARINFOEX);
+    ::SendMessage(window, WM_GETTITLEBARINFOEX, 0, (LPARAM)&title_bar_info);
+    int32_t title_bar_height =
+        title_bar_info.rcTitleBar.bottom - title_bar_info.rcTitleBar.top;
+    int32_t x = static_cast<int32_t>(
+        (std::get<double>(position[0]) * device_pixel_patio) + rect.left);
+    int32_t y = static_cast<int32_t>(
+        (std::get<double>(position[1]) * device_pixel_patio) + rect.top +
+        title_bar_height);
+    ::TrackPopupMenu(menu_handle_, TPM_LEFTALIGN | TPM_LEFTBUTTON, x, y, 0,
+                     window, NULL);
+#else
+    POINT point;
+    ::GetCursorPos(&point);
+    ::TrackPopupMenu(menu_handle_, TPM_LEFTALIGN | TPM_LEFTBUTTON, point.x,
+                     point.y, 0, window, NULL);
+#endif
+    result->Success(nullptr);
+  } else {
+    result->NotImplemented();
+  }
 }
 
-void NativeContextMenuPlugin::HandleMethodCall(const flutter::MethodCall<flutter::EncodableValue> &method_call,
-                                               std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result)
-{
-    if (method_call.method_name().compare("showMenu") == 0)
-    {
-        ShowMenu(method_call, std::move(result));
-    }
-    else
-    {
-        result->NotImplemented();
-    }
-}
+}  // namespace
 
-} // namespace
-
-void NativeContextMenuPluginRegisterWithRegistrar(FlutterDesktopPluginRegistrarRef registrar)
-{
-    NativeContextMenuPlugin::RegisterWithRegistrar(
-        flutter::PluginRegistrarManager::GetInstance()->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));
+void NativeContextMenuPluginRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  NativeContextMenuPlugin::RegisterWithRegistrar(
+      flutter::PluginRegistrarManager::GetInstance()
+          ->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));
 }


### PR DESCRIPTION
**This PR adds:**

- Linux support to the plugin.
- Refactored Windows implementation, to use `InvokeMethod` on C++ side to notify about selected menu item. And using `GetCursorPos` to get position for opening the context menu.
- Now passing `devicePixelRatio` and `position` arguments (from Dart) will result in context menu shown at the passed position, otherwise at the cursor position. 
- Following [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) on Windows & Linux.
- Other changes proposed from: #7.

![Screenshot_20211001_134609](https://user-images.githubusercontent.com/28951144/135587972-ae0cda3e-ee8f-4d7c-935b-40be67b992d0.jpg)

Thanks.