### PR TITLE
Add support for disabling menu items on macos

### DIFF
--- a/lib/src/context_menu_region.dart
+++ b/lib/src/context_menu_region.dart
@@ -52,6 +52,7 @@ class _ContextMenuRegionState extends State<ContextMenuRegion> {
         );
 
         if (selectedItem != null) {
+          selectedItem.onSelected?.call();
           widget.onItemSelected?.call(selectedItem);
         } else {
           widget.onDismissed?.call();

--- a/lib/src/method_channel.dart
+++ b/lib/src/method_channel.dart
@@ -31,6 +31,13 @@ class MenuItem {
   final List<MenuItem> items;
   final Object? action;
 
+  /// Allows a callback to be registered on an item-by-item basis (as opposed to the single
+  /// `ContextMenuRegion.onItemSelected` callback that is registered at the higher level.
+  /// If this value is not set, the menu item will be disabled. This is the case even for
+  /// nested menu items - if you want to disable a whole menu tree, you would set `onSelected`
+  /// for the root menu item to `null`. If you want to enable the menu tree, `onSelected`
+  /// must be non-`null` - an empty function works just fine. eg. `() {}`.  This function
+  /// will be called back if the user explicitly clicks on the root item of the sub-menu.
   final VoidCallback? onSelected;
 
   bool get hasSubitems => items.isNotEmpty;

--- a/lib/src/method_channel.dart
+++ b/lib/src/method_channel.dart
@@ -40,6 +40,7 @@ class MenuItem {
       'id': _id,
       'title': title,
       'items': items.map((e) => e.toJson()).toList(),
+      'enabled': onSelected != null,
     };
   }
 }

--- a/macos/Classes/NativeContextMenuPlugin.swift
+++ b/macos/Classes/NativeContextMenuPlugin.swift
@@ -80,6 +80,7 @@ public class NativeContextMenuPlugin: NSObject, FlutterPlugin, NSMenuDelegate {
                 action: #selector(onItemSelected(_:)), keyEquivalent: "")
 
             menuItem.representedObject = item
+            menuItem.isEnabled = item["enabled"] as! Bool
             
             return menuItem
         }


### PR DESCRIPTION
This PR addresses https://github.com/lesnitsky/native_context_menu/issues/11 on macos. A couple of important notes:

* There's an `onSelected` function on `MenuItem` that doesn't seem like it is used at the moment. It was a bit unclear what the difference was designed to be between this callback and `onItemSelected` in `ContextMenuRegion`. My assumption is that I'd use the former if I wanted different functions to be called back for each item, and I'd use the latter if I just wanted to have one function (and if both were present, then both would be called). However, as I mentioned, `MenuItem.onSelected` isn't currently hooked up, so I had to add a call to `ContextMenuRegion` to make sure it calls both. This assumption may not be correct, but was important for my decision on how to enable/disable each item.
* I consider adding a separate flag called `isEnabled` defaulting to `true`, however, I ended adopting the Flutter convention of disabling the widget if the `onSelected` function is not set. However, this would be a breaking change for any current users of this library (all menu items would be disabled unless they were setting the `onSelected` in their `MenuItem` objects - which they wouldn't be because those callbacks don't currently get called)

Windows and Linux have not been touched.

