### PR TITLE
Fixing compliation in Flutter 3.0

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide MenuItem;
 import 'package:native_context_menu/native_context_menu.dart';
 import 'package:window_manager/window_manager.dart';
 

--- a/lib/src/context_menu_region.dart
+++ b/lib/src/context_menu_region.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/gestures.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/widgets.dart' hide MenuItem;
 
 import 'method_channel.dart';
 


### PR DESCRIPTION
Flutter 3.0 adds its own `MenuItem` type, which conflicts with one of the types from this package and causes compilation errors when both are imported. This PR fixes the issue by just hiding the Flutter type in the import statements.